### PR TITLE
feat(info): pulsechain info via graph-dev + prefer rpc.pulsechain.box

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -41,6 +41,7 @@ export const SERVER_NODES = {
     'https://cloudflare-eth.com',
   ],
   [ChainId.PULSECHAIN]: [
+    'https://rpc.pulsechain.box',
     getNodeRealUrl(ChainId.PULSECHAIN, process.env.SERVER_NODE_REAL_API_PULSE) || '',
     'https://pulsechain-rpc.publicnode.com',
     'https://rpc-pulsechain.g4mm4.io',
@@ -124,6 +125,7 @@ export const PUBLIC_NODES: Record<ChainId, string[] | readonly string[]> = {
     'https://cloudflare-eth.com',
   ].filter(Boolean),
   [ChainId.PULSECHAIN]: [
+    'https://rpc.pulsechain.box',
     getNodeRealUrl(ChainId.PULSECHAIN, process.env.NEXT_PUBLIC_NODE_REAL_API_PULSE) || '',
     process.env.NEXT_PUBLIC_NODIES_PULSE || '',
     'https://pulsechain-rpc.publicnode.com',

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -3,10 +3,14 @@ import { withABTesting } from 'middlewares/ab-test-middleware'
 import { withClientId } from 'middlewares/client-id-middleware'
 import { withGeoBlock } from 'middlewares/geo-block-middleware'
 import { withUserIp } from 'middlewares/ip-address-middleware'
+import { withPulseExplorerApi } from 'middlewares/pulse-explorer-api-middleware'
 import { stackMiddlewares } from 'middlewares/stack-middleware'
 import { visitorRedirectMiddleware } from 'middlewares/visitor-rule-middleware'
 
 export const middleware = stackMiddlewares([
+  // First in the stack: short-circuit /api/cached/* requests so the UI-
+  // targeted middlewares below don't run on API paths.
+  withPulseExplorerApi,
   withClientId,
   withGeoBlock,
   withUserIp,
@@ -32,5 +36,6 @@ export const config = {
     '/lottery',
     '/nfts',
     '/info/:path*',
+    '/api/cached/:path*',
   ],
 }

--- a/apps/web/src/middlewares/pulse-explorer-api-middleware.ts
+++ b/apps/web/src/middlewares/pulse-explorer-api-middleware.ts
@@ -1,0 +1,60 @@
+import { NextFetchEvent, NextResponse } from 'next/server'
+import { ExtendedNextReq, MiddlewareFactory, NextMiddleware } from './types'
+
+const EXPLORER_API_BASE = 'https://graph-dev.9mm.pro'
+
+/**
+ * Routes /api/cached/**\/pulsechain/** requests to graph-dev.9mm.pro
+ * (explorer-api with Redis cache) instead of the local Next.js handler.
+ *
+ * The local /api/cached/* handlers call `multiChainId[chainName.toUpperCase()]`
+ * which maps "PULSE" → ChainId.PULSECHAIN, but the frontend URL contains
+ * "pulsechain" — which is not a key in that map, so requests get a 400
+ * "Unsupported chain: pulsechain". graph-dev accepts "pulsechain" directly
+ * and serves the same response shape via explorer-api over ponder-pulse.
+ *
+ * Scope: ONLY pulsechain paths. Other chains pass through to the local
+ * handler without further middleware processing.
+ *
+ * Failure mode: graceful — on graph-dev 5xx or network error, falls through
+ * to the local handler.
+ */
+export const withPulseExplorerApi: MiddlewareFactory = (next: NextMiddleware) => {
+  return async (request: ExtendedNextReq, event: NextFetchEvent) => {
+    const { pathname, search } = request.nextUrl
+
+    // Not an /api/cached/* path — continue normal middleware chain.
+    if (!pathname.startsWith('/api/cached/')) {
+      return next(request, event)
+    }
+
+    // For Pulse paths, proxy to graph-dev.
+    if (/\/pulsechain(\/|$)/i.test(pathname)) {
+      const devPath = pathname.replace(/^\/api\//, '/')
+      try {
+        const upstream = await fetch(`${EXPLORER_API_BASE}${devPath}${search}`, {
+          headers: { Accept: 'application/json' },
+          signal: AbortSignal.timeout(15000),
+        })
+        if (upstream.ok || upstream.status < 500) {
+          return new NextResponse(await upstream.text(), {
+            status: upstream.status,
+            headers: {
+              'Content-Type': upstream.headers.get('content-type') || 'application/json',
+              'X-Origin': 'graph-dev',
+              'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+            },
+          })
+        }
+      } catch {
+        // graph-dev unreachable — fall through to local handler.
+      }
+    }
+
+    // Non-Pulse /api/cached/* (or graph-dev failure) — let Next.js route to the
+    // local API handler, skipping the rest of the middleware stack. The other
+    // middlewares (geo-block, AB-test, ...) target UI routes and shouldn't
+    // affect API calls.
+    return NextResponse.next()
+  }
+}

--- a/apps/web/src/middlewares/pulse-explorer-api-middleware.ts
+++ b/apps/web/src/middlewares/pulse-explorer-api-middleware.ts
@@ -16,8 +16,9 @@ const EXPLORER_API_BASE = 'https://graph-dev.9mm.pro'
  * Scope: ONLY pulsechain paths. Other chains pass through to the local
  * handler without further middleware processing.
  *
- * Failure mode: graceful — on graph-dev 5xx or network error, falls through
- * to the local handler.
+ * Failure mode: graceful — on any non-2xx response from graph-dev or network
+ * error/timeout, falls through to the local handler. Errors are logged to the
+ * server console for observability.
  */
 export const withPulseExplorerApi: MiddlewareFactory = (next: NextMiddleware) => {
   return async (request: ExtendedNextReq, event: NextFetchEvent) => {
@@ -34,9 +35,9 @@ export const withPulseExplorerApi: MiddlewareFactory = (next: NextMiddleware) =>
       try {
         const upstream = await fetch(`${EXPLORER_API_BASE}${devPath}${search}`, {
           headers: { Accept: 'application/json' },
-          signal: AbortSignal.timeout(15000),
+          signal: AbortSignal.timeout(5000),
         })
-        if (upstream.ok || upstream.status < 500) {
+        if (upstream.ok) {
           return new NextResponse(await upstream.text(), {
             status: upstream.status,
             headers: {
@@ -46,8 +47,16 @@ export const withPulseExplorerApi: MiddlewareFactory = (next: NextMiddleware) =>
             },
           })
         }
-      } catch {
-        // graph-dev unreachable — fall through to local handler.
+        // Non-2xx from graph-dev — log and fall through to local handler.
+        console.warn(
+          `[pulse-explorer-api] graph-dev returned ${upstream.status} for ${devPath} — falling back to local handler`,
+        )
+      } catch (err) {
+        // Network error / timeout — log and fall through to local handler.
+        const msg = err instanceof Error ? err.message : String(err)
+        console.warn(
+          `[pulse-explorer-api] graph-dev fetch failed for ${devPath}: ${msg} — falling back to local handler`,
+        )
       }
     }
 


### PR DESCRIPTION
## Summary

Two related Pulse-info hardening changes to the main dex.

1. **Middleware** (`apps/web/src/middlewares/pulse-explorer-api-middleware.ts`):
   route `/api/cached/**/pulsechain/**` requests to `graph-dev.9mm.pro`
   (explorer-api with Redis cache, backed by ponder-pulse) instead of the
   local Next.js handler. The local handler maps `chainName.toUpperCase()`
   → `multiChainId['PULSECHAIN']` which doesn't exist in that map for the
   spelling "pulsechain", so those requests currently return HTTP 400
   "Unsupported chain: pulsechain". graph-dev accepts "pulsechain" directly
   and returns shape-compatible responses.

2. **RPC priority** (`apps/web/src/config/nodes.ts`): add
   `https://rpc.pulsechain.box` as the first entry in both
   `SERVER_NODES.PULSECHAIN` (server-side viem clients incl. NFT position
   lookup) and `PUBLIC_NODES.PULSECHAIN` (browser wagmi). Existing public
   RPCs (NodeReal, publicnode, g4mm4, pulsechain.com) stay as fallbacks
   via viem's `fallback()` transport.

A small audit-cleanup follow-on (commit `fix(info): tighten ...`) also tightens the middleware: strict 2xx-only graph-dev use, 20s → 5s upstream timeout, and `console.warn` on fall-through for observability.

## Scope

Both changes are strictly scoped to Pulsechain:
- Middleware regex `/\/pulsechain(\/|$)/i` only fires on URLs containing `/pulsechain/`. Other chains (`/pulse/`, `/eth/`, `/base/`, `/bsc/`, `/sonic/`) pass through unchanged.
- RPC change only touches the `[ChainId.PULSECHAIN]` key in the nodes config dictionaries; other chains' RPC lists are untouched.

## Failure mode

Graceful fallback in both cases:
- Middleware: 5s timeout / non-2xx response from graph-dev → `console.warn` + fall through to local Next.js handler (which 400s — same as today).
- RPC: viem's `fallback()` transport rotates to the next URL on failure of any provider.

## Test plan

- [ ] On deploy: hit `https://dex.9mm.pro/api/cached/protocol/v3/pulsechain/stats` — currently 400, becomes 200 with stats from graph-dev
- [ ] On deploy: hit `/api/cached/protocol/v3/pulse/stats` — unchanged, local handler still serves it (`pulse` spelling still works)
- [ ] On deploy: NFT position lookup at `/api/cached/position/lookup/<tokenId>` — works (uses SERVER_NODES, now prefers rpc.pulsechain.box for Pulse on-chain reads)
- [ ] On deploy: wallet connect on Pulsechain in browser — RPC requests go to rpc.pulsechain.box first (visible in DevTools Network panel)
- [ ] On deploy: no regression on other chains (eth/base/bsc/sonic `/api/cached` requests unaffected, wallet RPC unaffected)
- [ ] On deploy: simulated rpc.pulsechain.box outage — viem fallback rotates transparently to NodeReal → publicnode → g4mm4 → pulsechain.com