### PR TITLE
feat(info): extend middleware to also catch /pulse/ slug for Info pages

### DIFF
--- a/apps/web/src/middlewares/pulse-explorer-api-middleware.ts
+++ b/apps/web/src/middlewares/pulse-explorer-api-middleware.ts
@@ -4,16 +4,18 @@ import { ExtendedNextReq, MiddlewareFactory, NextMiddleware } from './types'
 const EXPLORER_API_BASE = 'https://graph-dev.9mm.pro'
 
 /**
- * Routes /api/cached/**\/pulsechain/** requests to graph-dev.9mm.pro
+ * Routes /api/cached/**\/(pulse|pulsechain)/** requests to graph-dev.9mm.pro
  * (explorer-api with Redis cache) instead of the local Next.js handler.
  *
- * The local /api/cached/* handlers call `multiChainId[chainName.toUpperCase()]`
- * which maps "PULSE" → ChainId.PULSECHAIN, but the frontend URL contains
- * "pulsechain" — which is not a key in that map, so requests get a 400
- * "Unsupported chain: pulsechain". graph-dev accepts "pulsechain" directly
- * and serves the same response shape via explorer-api over ponder-pulse.
+ * Both slugs are caught because the frontend uses different spellings in
+ * different code paths: `multiChainPaths[PULSECHAIN] = '/pulse'` (used by
+ * Info/V3Info pages) and `multiChainPriceAPIPaths[PULSECHAIN] = '/pulsechain'`
+ * (used by price-api). The local /api/cached/* handlers map "PULSE" via
+ * multiChainId but produce subgraph queries against graph.9mm.pro, whose
+ * aggregation layer drifts vs the Ponder-backed explorer-api at graph-dev
+ * (see project_explorer_api_subgraph_gap memory).
  *
- * Scope: ONLY pulsechain paths. Other chains pass through to the local
+ * Scope: ONLY pulse/pulsechain paths. Other chains pass through to the local
  * handler without further middleware processing.
  *
  * Failure mode: graceful — on any non-2xx response from graph-dev or network
@@ -29,8 +31,8 @@ export const withPulseExplorerApi: MiddlewareFactory = (next: NextMiddleware) =>
       return next(request, event)
     }
 
-    // For Pulse paths, proxy to graph-dev.
-    if (/\/pulsechain(\/|$)/i.test(pathname)) {
+    // For Pulse paths (either /pulse/ or /pulsechain/), proxy to graph-dev.
+    if (/\/pulse(chain)?(\/|$)/i.test(pathname)) {
       const devPath = pathname.replace(/^\/api\//, '/')
       try {
         const upstream = await fetch(`${EXPLORER_API_BASE}${devPath}${search}`, {


### PR DESCRIPTION
## Summary

Extends the `withPulseExplorerApi` middleware (shipped in #8) to also catch the `/pulse/` slug,
not just `/pulsechain/`. This is the slug Info/V3Info pages actually use via
`multiChainPaths[ChainId.PULSECHAIN] = '/pulse'`.

PR #8 only caught `/pulsechain/` (used by price-api etc.), so Info pages were
still hitting the local Next.js handler → `graph.9mm.pro` V3 subgraph, whose
aggregation layer drifts from the Ponder-backed explorer-api at `graph-dev.9mm.pro`
(see `project_explorer_api_subgraph_gap` memory).

After this PR, `/api/cached/.../pulse/...` URLs from Info pages route to
graph-dev too. The frontend immediately sees the more-accurate Ponder values
for V3 pages.

## Change

One regex update in `apps/web/src/middlewares/pulse-explorer-api-middleware.ts`:
```diff
- if (/\/pulsechain(\/|$)/i.test(pathname)) {
+ if (/\/pulse(chain)?(\/|$)/i.test(pathname)) {
```

Verified the new regex against 17 path patterns — matches `/pulse/` and
`/pulsechain/` (both case-insensitive); doesn't match `/pulse-bar`,
`/pulsex`, `/pulsechainx`, or substring-only matches like `foo-pulsechain-bar`.

## Caveat: V2 paths

graph-dev's Ponder indexers don't have V2 data yet (V2 backfill on CT 669 is
mid-backfill as of this PR — should complete same day). V2 `/cached/.../v2/...`
calls to graph-dev return empty `{}` / `[]`. After this PR, V2 Info pages
on Pulse will temporarily show empty rather than the graph.9mm.pro values,
until the V2 backfill lands in K8s.

## Test plan

- [ ] After merge + rollout-restart: visit dex.9mm.pro/info/v3/pulse/... pages — TVL/volume/fees match graph-dev numbers (currently ~3.48M TVL, ~1.09B volume), not the older graph.9mm.pro numbers (1.38M / 789M)
- [ ] V3 token list, pool detail, swap history all populate from graph-dev (visible in DevTools: `x-origin: graph-dev`)
- [ ] V2 pages temporarily empty (expected — until V2 backfill K8s deploy)
- [ ] Non-Pulse chain Info pages unchanged
- [ ] NFT position lookup unchanged (chain-agnostic path)