### PR TITLE
fix(subgraph): point Pulse subgraph URLs at subgraph.9mm.pro

### DIFF
--- a/packages/chains/src/subgraphs.ts
+++ b/packages/chains/src/subgraphs.ts
@@ -27,7 +27,7 @@ export function getStableSwapSubgraphs({ theGraphApiKey }: Pick<SubgraphParams, 
 export function getV3Subgraphs({ noderealApiKey, theGraphApiKey }: SubgraphParams) {
   return {
     [ChainId.ETHEREUM]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/45F3dvAke57HRSEQfjoirVuzVKeiyS4oQKfmrZ742UxG`,
-    [ChainId.PULSECHAIN]: `https://graph.9mm.pro/subgraphs/name/pulsechain/9mm-v3-latest`,
+    [ChainId.PULSECHAIN]: `https://subgraph.9mm.pro/subgraphs/name/pulsechain/9mm-v3-latest`,
     [ChainId.OPTIPULSE]: `https://testnet-graphs.optipulse.io/subgraphs/name/optipulse/v3`,
     [ChainId.SONIC]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/EatYuv9ktFGrSDGRw9cNwkKXweCX52hRAiamGXQb29Ah`,
     [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
@@ -58,7 +58,7 @@ export function getV2Subgraphs({ noderealApiKey, theGraphApiKey }: SubgraphParam
   return {
     [ChainId.BSC]: `https://api.studio.thegraph.com/query/80328/bnb-v-2/version/latest`,
     [ChainId.ETHEREUM]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/GH9mv6ABa7gZcwi84CvfQeWWNT1rWwcKjb72DySLTgAd`,
-    [ChainId.PULSECHAIN]: `https://graph.9mm.pro/subgraphs/name/pulsechain/9mm`,
+    [ChainId.PULSECHAIN]: `https://subgraph.9mm.pro/subgraphs/name/pulsechain/9mm`,
     [ChainId.OPTIPULSE]: `https://testnet-graphs.optipulse.io/subgraphs/name/optipulse/v2`,
     [ChainId.SONIC]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/3BKTRZC8H2zfh4CohDNk6EoRt78o9k1sUfXeFwKSAARf`,
     [ChainId.POLYGON_ZKEVM]: `https://gateway-arbitrum.network.thegraph.com/api/${theGraphApiKey}/subgraphs/id/37WmH5kBu6QQytRpMwLJMGPRbXvHgpuZsWqswW4Finc2`,
@@ -76,7 +76,7 @@ export function getBlocksSubgraphs({ noderealApiKey, theGraphApiKey }: SubgraphP
   return {
     [ChainId.BSC]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/9dSPXfKXaqYpoGAPXx96LyDF1VYR8PiT6HA7HRKEGRdS`,
     [ChainId.ETHEREUM]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/9A6bkprqEG2XsZUYJ5B2XXp6ymz9fNcn4tVPxMWDztYC`,
-    [ChainId.PULSECHAIN]: 'https://graph.9mm.pro/subgraphs/name/block-client',
+    [ChainId.PULSECHAIN]: 'https://subgraph.9mm.pro/subgraphs/name/block-client',
     [ChainId.OPTIPULSE]: 'https://testnet-graphs.optipulse.io/subgraphs/name/block-client',
     [ChainId.SONIC]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/JCDpWYWQrdeehm9dPthvU3QUgNE6VfqTmFYeumXNemDE`,
     [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/polygon-zkevm-block/version/latest',


### PR DESCRIPTION
## Summary

Points the three Pulsechain subgraph URLs in `packages/chains/src/subgraphs.ts`
from `graph.9mm.pro` (graph-server Linode VM at 66.228.55.64) to
`subgraph.9mm.pro` (in-cluster explorer-api on LKE, backed by Ponder).

- V3: `graph.9mm.pro/subgraphs/name/pulsechain/9mm-v3-latest` → `subgraph.9mm.pro/subgraphs/name/pulsechain/9mm-v3-latest`
- V2: `graph.9mm.pro/subgraphs/name/pulsechain/9mm` → `subgraph.9mm.pro/subgraphs/name/pulsechain/9mm`
- block-client: `graph.9mm.pro/subgraphs/name/block-client` → `subgraph.9mm.pro/subgraphs/name/block-client`

PULSECHAIN-only — all other chains continue to use the real TheGraph endpoints
(`gateway.thegraph.com`, `gateway-arbitrum.network.thegraph.com`, NodeReal,
etc.). The diff is 3 line changes, no deletions.

## Why

graph-server (Linode VM) is being retired. The in-cluster `subgraph.9mm.pro`
endpoint (Ingress shipped today) routes to `explorer-api` Service in LKE which
serves the same GraphQL schema backed by Ponder. After this PR, the dex.9mm.pro
smart-router + V3/V2 chart/lookup paths read from in-cluster infra instead of
the external Linode box. Drop-in replacement.

## Compatibility

- Same GraphQL schema (PCS-V3 subgraph drop-in via graphql-yoga in explorer-api)
- Same `/subgraphs/name/pulsechain/{9mm-v3-latest,9mm,block-client}` URL paths
- Same response shapes for V3 (Pool, Token, Swap, Burn, Mint, Position, etc.)
- Subgraph metadata: V3 returns 96.3M TVL / 24,437 pools / 13.6M tx — matches Ponder
- V2 path returns explorer-api data (V2 Ponder backfill in flight today; until landed, V2 returns aggregated stats from V3 schema — same as graph.9mm.pro V2 was returning in many cases per project_explorer_api_subgraph_gap memory)
- block-client path served by explorer-api shim

## Failure mode

If subgraph.9mm.pro has an outage:
- viem fallback transport doesn't apply (this is GraphQL, not RPC)
- Frontend will see GraphQL errors / loading states
- Quick rollback: revert the 3-line change + redeploy
- graph.9mm.pro stays online during transition (consumer rollback target)

## Test plan

- [ ] After merge + deploy: dex.9mm.pro/info/v3/pulse — V3 charts/tokens populate from subgraph.9mm.pro
- [ ] Browser DevTools: see GraphQL POSTs going to subgraph.9mm.pro (not graph.9mm.pro)
- [ ] Smart-router quote for a Pulse swap: confirms V3 subgraph queries succeed end-to-end
- [ ] Block-by-timestamp lookup: "X days ago" chart selectors still work
- [ ] No regression on other chains (ETH/BSC/Base/Sonic Info pages still hit real TheGraph)