### PR TITLE
chore: swap price-api.9mm.pro to price-api-dev.9mm.pro

### DIFF
--- a/apps/web/src/hooks/useCakePrice.ts
+++ b/apps/web/src/hooks/useCakePrice.ts
@@ -58,7 +58,7 @@ const fetchCakePrice = async (_chainId: number): Promise<BigNumber> => {
 
     // First try to fetch from 9mm API
     try {
-      const apiUrl = `https://price-api.9mm.pro/api/price${multiChainPriceAPIPaths[chainId]}/?address=${_cake.address}`
+      const apiUrl = `https://price-api-dev.9mm.pro/api/price${multiChainPriceAPIPaths[chainId]}/?address=${_cake.address}`
       const apiResponse = await fetch(apiUrl)
       const apiData = await apiResponse.json()
 

--- a/apps/web/src/lib/tokenOverrides.ts
+++ b/apps/web/src/lib/tokenOverrides.ts
@@ -16,7 +16,7 @@
 import { multiChainPriceAPIPaths } from 'state/info/constant'
 
 export type TokenOverride = {
-  /** Pull the live price from price-api.9mm.pro instead of trusting the
+  /** Pull the live price from price-api-dev.9mm.pro instead of trusting the
    *  subgraph-derived value. Use for tokens whose `derivedETH` is broken.
    *  When set, the override also rewrites `tvlUSD` (from token-unit `tvl` ×
    *  live price) and flattens the three historical price fields to the live
@@ -64,7 +64,7 @@ async function fetchLivePrice(chainId: number, address: string): Promise<number 
   const path = (multiChainPriceAPIPaths as Record<number, string>)[chainId]
   if (!path) return null
   try {
-    const res = await fetch(`https://price-api.9mm.pro/api/price${path}/?address=${address}`, {
+    const res = await fetch(`https://price-api-dev.9mm.pro/api/price${path}/?address=${address}`, {
       signal: AbortSignal.timeout(4000),
     })
     if (!res.ok) return null
@@ -110,10 +110,7 @@ type OverridableTokenRow = {
  * Returns a new array; does not mutate the input. Rows for chains that have
  * no overrides (`TOKEN_OVERRIDES[chainId]` undefined) are returned as-is.
  */
-export async function applyTokenOverrides<T extends OverridableTokenRow>(
-  chainId: number,
-  rows: T[],
-): Promise<T[]> {
+export async function applyTokenOverrides<T extends OverridableTokenRow>(chainId: number, rows: T[]): Promise<T[]> {
   const overrides = TOKEN_OVERRIDES[chainId]
   if (!overrides) return rows
 

--- a/packages/farms/src/fetchFarmsV3.ts
+++ b/packages/farms/src/fetchFarmsV3.ts
@@ -45,7 +45,7 @@ const fetchCakePrice = async (_chainId: number): Promise<string> => {
     // First try to fetch from 9mm API
     try {
       // @ts-ignore
-      const apiUrl = `https://price-api.9mm.pro/api/price${multiChainPriceAPIPaths[chainId]}/?address=${_cake.address}`
+      const apiUrl = `https://price-api-dev.9mm.pro/api/price${multiChainPriceAPIPaths[chainId]}/?address=${_cake.address}`
       const apiResponse = await fetch(apiUrl)
       const apiData = await apiResponse.json()
 


### PR DESCRIPTION
Three frontend files hardcoded `https://price-api.9mm.pro` for live-price fetches (token overrides, CAKE/9mm token price, V3 farm APR). That hostname is the legacy 9x-server Linode instance — currently unhealthy (`/api/health` 404, `/api/price/{chain}` timeouts). Browser console errors confirm: `GET https://price-api.9mm.pro/api/price/basechain/?address=0xe290816... 500`.

Swaps the three call sites to `https://price-api-dev.9mm.pro` — our in-cluster K8s instance of the same codebase, healthy and returning matching `{"price":"..."}` payloads. Same path contract, no client-side logic changes.

Verified:
- `https://price-api-dev.9mm.pro/api/health` → HTTP 200 `{"ok":true,...}`
- `https://price-api-dev.9mm.pro/api/price/basechain?address=0xe290...` → HTTP 200 `{"price":"0.00176..."}`