### PR TITLE
fix(endpoints): stop overriding V2/V3 subgraph URLs with PCS proxy (use TheGraph gateway)

### DIFF
--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -42,37 +42,30 @@ export const ACCESS_RISK_API = 'https://red.alert.pancakeswap.com/red-api'
 
 export const CELER_API = 'https://api.celerscan.com/scan'
 
-export const V2_SUBGRAPH_URLS = {
-  ...V2_SUBGRAPHS,
-  [ChainId.POLYGON_ZKEVM]: `${THE_GRAPH_PROXY_API}/exchange-v2-polygon-zkevm`,
-  [ChainId.ETHEREUM]: `${THE_GRAPH_PROXY_API}/exchange-v2-eth`,
-  [ChainId.BSC]: `${THE_GRAPH_PROXY_API}/exchange-v2-bsc`,
-  [ChainId.ARBITRUM_ONE]: `${THE_GRAPH_PROXY_API}/exchange-v2-arb`,
-  [ChainId.ZKSYNC]: `${THE_GRAPH_PROXY_API}/exchange-v2-zksync`,
-  [ChainId.LINEA]: `${THE_GRAPH_PROXY_API}/exchange-v2-linea`,
-  [ChainId.OPBNB]: `${THE_GRAPH_PROXY_API}/exchange-v2-opbnb`,
-}
+// V2_SUBGRAPHS (from @pancakeswap/chains) already returns official TheGraph
+// gateway URLs keyed by NEXT_PUBLIC_THE_GRAPH_API_KEY for ETH/BSC/Base/Sonic/
+// Arb/Linea/zkSync/Polygon-zkEVM, plus our own subgraph.9mm.pro for Pulse
+// (TheGraph doesn't index PulseChain). The previous PCS-proxy overrides here
+// pointed at thegraph.pancakeswap.com which doesn't whitelist our origin —
+// fall through to the source map instead.
+export const V2_SUBGRAPH_URLS = V2_SUBGRAPHS
 export const INFO_CLIENT_ETH = V2_SUBGRAPH_URLS[ChainId.ETHEREUM]
 
 export const BLOCKS_CLIENT_WITH_CHAIN = BLOCKS_SUBGRAPH_URLS
 
 export const ASSET_CDN = process.env.NEXT_PUBLIC_ASSET_CDN || 'https://tokens.9mm.pro'
 
-export const V3_SUBGRAPH_URLS = {
-  ...V3_SUBGRAPHS,
-  [ChainId.POLYGON_ZKEVM]: `${THE_GRAPH_PROXY_API}/exchange-v3-polygon-zkevm`,
-  [ChainId.ETHEREUM]: `${THE_GRAPH_PROXY_API}/exchange-v3-eth`,
-  [ChainId.BSC]: `${THE_GRAPH_PROXY_API}/exchange-v3-bsc`,
-  [ChainId.ARBITRUM_ONE]: `${THE_GRAPH_PROXY_API}/exchange-v3-arb`,
-  [ChainId.ZKSYNC]: `${THE_GRAPH_PROXY_API}/exchange-v3-zksync`,
-  [ChainId.LINEA]: `${THE_GRAPH_PROXY_API}/exchange-v3-linea`,
-  [ChainId.OPBNB]: `${THE_GRAPH_PROXY_API}/exchange-v3-opbnb`,
-}
+// Same as V2: V3_SUBGRAPHS already has TheGraph gateway URLs per chain plus
+// subgraph.9mm.pro for Pulse. The PCS-proxy overrides previously here CORS-
+// blocked because our origin isn't whitelisted on thegraph.pancakeswap.com.
+export const V3_SUBGRAPH_URLS = V3_SUBGRAPHS
 
+// Stableswap is BSC + Arbitrum on PCS; we don't run stableswap pools, so the
+// PCS-proxy URL for Arb just adds CORS noise. Fall through to packages/chains
+// (which has Arb's TheGraph URL); set ETH/BSC/OptiPulse to empty as before.
 export const STABLESWAP_SUBGRAPHS_URLS = {
   ...STABLESWAP_SUBGRAPHS,
   [ChainId.BSC]: ``,
-  [ChainId.ARBITRUM_ONE]: `${THE_GRAPH_PROXY_API}/exchange-stableswap-arb`,
   [ChainId.ETHEREUM]: ``,
   [ChainId.OPTIPULSE]: '',
 }


### PR DESCRIPTION
Follow-up to PR #17. Removes the PCS-proxy URL overrides in `apps/web/src/config/constants/endpoints.ts` that pointed V2/V3 subgraph URLs at `thegraph.pancakeswap.com` (which CORS-blocks our origin). The underlying `V2_SUBGRAPHS`/`V3_SUBGRAPHS` maps in `@pancakeswap/chains` already return official `gateway.thegraph.com` URLs keyed by `NEXT_PUBLIC_THE_GRAPH_API_KEY` for every chain except Pulse (which uses our own `subgraph.9mm.pro`), so dropping the overrides Just Works™ via the existing GH secret.

## Verification
- Tested on `dex-dev.9mm.pro` (post #17 merge cycle).
- Confirmed bundle has 0 chunks referencing `thegraph.pancakeswap.com/exchange-v[23]-*` after the patch (down from 9 chains).
- `gateway.thegraph.com` URLs in bundle for ETH/BSC/Base/Sonic/Arb/Linea/zkSync/Polygon-zkEVM.
- `/info/v3/ethereum` HTTP 200, no CORS errors in dev browser console.

## Note
The remaining `THE_GRAPH_PROXY_API` references in `endpoints.ts` (profile / lottery / pottery / prediction / nft-marketplace / trading-competition / blocks-opbnb) are PCS-only services we don't render — separate concern.