### PR TITLE
feat(subgraphs): route non-Pulse (eth/bsc/sonic/base) v3/v2/blocks via graph.9mm.pro

### DIFF
--- a/packages/chains/src/subgraphs.ts
+++ b/packages/chains/src/subgraphs.ts
@@ -26,12 +26,12 @@ export function getStableSwapSubgraphs({ theGraphApiKey }: Pick<SubgraphParams, 
 
 export function getV3Subgraphs({ noderealApiKey, theGraphApiKey }: SubgraphParams) {
   return {
-    [ChainId.ETHEREUM]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/45F3dvAke57HRSEQfjoirVuzVKeiyS4oQKfmrZ742UxG`,
+    [ChainId.ETHEREUM]: 'https://graph.9mm.pro/subgraphs/name/eth/9mm-v3-latest',
     [ChainId.PULSECHAIN]: `https://subgraph.9mm.pro/subgraphs/name/pulsechain/9mm-v3-latest`,
     [ChainId.OPTIPULSE]: `https://testnet-graphs.optipulse.io/subgraphs/name/optipulse/v3`,
-    [ChainId.SONIC]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/EatYuv9ktFGrSDGRw9cNwkKXweCX52hRAiamGXQb29Ah`,
+    [ChainId.SONIC]: 'https://graph.9mm.pro/subgraphs/name/sonic/9mm-v3-latest',
     [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
-    [ChainId.BSC]: 'https://api.studio.thegraph.com/query/80328/bsc-v-3/version/latest',
+    [ChainId.BSC]: 'https://graph.9mm.pro/subgraphs/name/bsc/9mm-v3-latest',
     [ChainId.BSC_TESTNET]: `https://gateway-arbitrum.network.thegraph.com/api/${theGraphApiKey}/subgraphs/id/7xd5KmL3FbzRYbmAM9SSe4wdrsJV71pJQhCBqzU7y8Qi`,
     [ChainId.ARBITRUM_ONE]: `https://gateway-arbitrum.network.thegraph.com/api/${theGraphApiKey}/subgraphs/id/251MHFNN1rwjErXD2efWMpNS73SANZN8Ua192zw6iXve`,
     [ChainId.ARBITRUM_GOERLI]: 'https://api.thegraph.com/subgraphs/name/chef-jojo/exhange-v3-arb-goerli',
@@ -42,7 +42,7 @@ export function getV3Subgraphs({ noderealApiKey, theGraphApiKey }: SubgraphParam
     [ChainId.LINEA]: `https://gateway-arbitrum.network.thegraph.com/api/${theGraphApiKey}/subgraphs/id/6gCTVX98K3A9Hf9zjvgEKwjz7rtD4C1V173RYEdbeMFX`,
     [ChainId.LINEA_TESTNET]:
       'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
-    [ChainId.BASE]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/BnAEbKRkCW2oKKggWn8AKP7NVQhwJTaxMMfio5ngCZRV`,
+    [ChainId.BASE]: 'https://graph.9mm.pro/subgraphs/name/base/9mm-v3-latest',
     [ChainId.BASE_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base-testnet/version/latest',
     [ChainId.OPBNB]: `https://open-platform-ap.nodereal.io/${noderealApiKey}/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/exchange-v3`,
     [ChainId.OPBNB_TESTNET]: null,
@@ -56,34 +56,34 @@ export function getV3Subgraphs({ noderealApiKey, theGraphApiKey }: SubgraphParam
 
 export function getV2Subgraphs({ noderealApiKey, theGraphApiKey }: SubgraphParams) {
   return {
-    [ChainId.BSC]: `https://api.studio.thegraph.com/query/80328/bnb-v-2/version/latest`,
-    [ChainId.ETHEREUM]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/GH9mv6ABa7gZcwi84CvfQeWWNT1rWwcKjb72DySLTgAd`,
+    [ChainId.BSC]: 'https://graph.9mm.pro/subgraphs/name/bsc/9mm',
+    [ChainId.ETHEREUM]: 'https://graph.9mm.pro/subgraphs/name/eth/9mm',
     [ChainId.PULSECHAIN]: `https://subgraph.9mm.pro/subgraphs/name/pulsechain/9mm`,
     [ChainId.OPTIPULSE]: `https://testnet-graphs.optipulse.io/subgraphs/name/optipulse/v2`,
-    [ChainId.SONIC]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/3BKTRZC8H2zfh4CohDNk6EoRt78o9k1sUfXeFwKSAARf`,
+    [ChainId.SONIC]: 'https://graph.9mm.pro/subgraphs/name/sonic/9mm',
     [ChainId.POLYGON_ZKEVM]: `https://gateway-arbitrum.network.thegraph.com/api/${theGraphApiKey}/subgraphs/id/37WmH5kBu6QQytRpMwLJMGPRbXvHgpuZsWqswW4Finc2`,
     [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-zksync-testnet/version/latest',
     [ChainId.ZKSYNC]: `https://gateway-arbitrum.network.thegraph.com/api/${theGraphApiKey}/subgraphs/id/6dU6WwEz22YacyzbTbSa3CECCmaD8G7oQ8aw6MYd5VKU`,
     [ChainId.LINEA_TESTNET]: 'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exhange-eth/',
     [ChainId.ARBITRUM_ONE]: `https://gateway-arbitrum.network.thegraph.com/api/${theGraphApiKey}/subgraphs/id/EsL7geTRcA3LaLLM9EcMFzYbUgnvf8RixoEEGErrodB3`,
     [ChainId.LINEA]: `https://gateway-arbitrum.network.thegraph.com/api/${theGraphApiKey}/subgraphs/id/Eti2Z5zVEdARnuUzjCbv4qcimTLysAizsqH3s6cBfPjB`,
-    [ChainId.BASE]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/AGSFbAGFt8y1ztxRAV6t6rVtdiP5MBLBiHUUFfYuVnEf`,
+    [ChainId.BASE]: 'https://graph.9mm.pro/subgraphs/name/base/9mm',
     [ChainId.OPBNB]: `https://open-platform-ap.nodereal.io/${noderealApiKey}/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/exchange-v2`,
   }
 }
 
 export function getBlocksSubgraphs({ noderealApiKey, theGraphApiKey }: SubgraphParams) {
   return {
-    [ChainId.BSC]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/9dSPXfKXaqYpoGAPXx96LyDF1VYR8PiT6HA7HRKEGRdS`,
-    [ChainId.ETHEREUM]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/9A6bkprqEG2XsZUYJ5B2XXp6ymz9fNcn4tVPxMWDztYC`,
+    [ChainId.BSC]: 'https://graph.9mm.pro/subgraphs/name/bsc/blocks',
+    [ChainId.ETHEREUM]: 'https://graph.9mm.pro/subgraphs/name/eth/blocks',
     [ChainId.PULSECHAIN]: 'https://subgraph.9mm.pro/subgraphs/name/block-client',
     [ChainId.OPTIPULSE]: 'https://testnet-graphs.optipulse.io/subgraphs/name/block-client',
-    [ChainId.SONIC]: `https://gateway.thegraph.com/api/${theGraphApiKey}/subgraphs/id/JCDpWYWQrdeehm9dPthvU3QUgNE6VfqTmFYeumXNemDE`,
+    [ChainId.SONIC]: 'https://graph.9mm.pro/subgraphs/name/sonic/blocks',
     [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/polygon-zkevm-block/version/latest',
     [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/blocks-zksync/version/latest',
     [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
     [ChainId.LINEA]: 'https://api.studio.thegraph.com/query/45376/blocks-linea/version/latest',
-    [ChainId.BASE]: 'https://api.studio.thegraph.com/query/48211/base-blocks/version/latest',
+    [ChainId.BASE]: 'https://graph.9mm.pro/subgraphs/name/base/blocks',
     [ChainId.OPBNB]: `https://open-platform-ap.nodereal.io/${noderealApiKey}/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/blocks`,
   } as const
 }


### PR DESCRIPTION
## What
Route the **non-Pulse** subgraphs (ETH / BSC / Sonic / Base — v3, v2, blocks) through `graph.9mm.pro` (explorer-api) instead of calling The Graph directly. Single-file change in `packages/chains/src/subgraphs.ts`. PulseChain, OptiPulse, and the unused PCS-leftover chains are untouched.

## Why
- **Removes the API-key leak.** Today these chains use `gateway.thegraph.com/api/${NEXT_PUBLIC_THE_GRAPH_API_KEY}/…`, and `NEXT_PUBLIC_*` is inlined into the public browser bundle — anyone can extract the key and run queries on our Graph bill. After this, these chains hit `graph.9mm.pro`, which injects the key **server-side**.
- **Single origin** for every chain (graph.9mm.pro), matching how Pulse already works.
- Pure passthrough — explorer-api returns The Graph's response verbatim, so data is byte-identical to today.

## Dependency — already deployed & verified
The explorer-api allowlisted Graph proxy is **live in prod** (gitlab MR !3, image `cb16078c`). Verified through `graph.9mm.pro`:
- `base/eth/sonic v3` return real Graph data via the proxy (`x-graph-proxy` header present).
- Pulse paths are unaffected (still served by Ponder).
So this PR is safe to merge — the backend it points at is already serving.

## Companion ops steps (not in this PR)
1. After this ships & is verified, **drop `NEXT_PUBLIC_THE_GRAPH_API_KEY`** from the dex build env so the key stops being inlined for the remaining (unused) PCS chains.
2. **Rotate** the currently-exposed Graph key (explorer-api holds it server-side in the `the-graph-api` secret).

## Caveat (pre-existing, not introduced here)
BSC v3/v2 use The Graph **studio** endpoints (`api.studio.thegraph.com/query/80328/…`) which are **dead upstream** ("deployment does not exist") due to The Graph's hosted-service sunset. This is already broken on the live dex today. Routing via explorer-api doesn't fix it (the proxy faithfully forwards to the same dead studio subgraph) — BSC v3/v2 need a new decentralized-network deployment. BSC blocks + all of ETH/Sonic/Base work.

## Test
Verified each repointed endpoint live via `graph.9mm.pro/subgraphs/name/<chain>/<name>` returns the expected data (ETH/Sonic/Base). No dep changes.
