### PR TITLE
fix(subgraphs): drop unused theGraphApiKey param in getBlocksSubgraphs

### DIFF
--- a/packages/chains/src/subgraphs.ts
+++ b/packages/chains/src/subgraphs.ts
@@ -72,7 +72,7 @@ export function getV2Subgraphs({ noderealApiKey, theGraphApiKey }: SubgraphParam
   }
 }
 
-export function getBlocksSubgraphs({ noderealApiKey, theGraphApiKey }: SubgraphParams) {
+export function getBlocksSubgraphs({ noderealApiKey }: SubgraphParams) {
   return {
     [ChainId.BSC]: 'https://graph.9mm.pro/subgraphs/name/bsc/blocks',
     [ChainId.ETHEREUM]: 'https://graph.9mm.pro/subgraphs/name/eth/blocks',


### PR DESCRIPTION
## What
One-line build fix for the failed `Build & Deploy DEX Main` run from #19.

After #19 repointed all of `getBlocksSubgraphs`' gateway entries (ETH/Sonic/BSC) to `graph.9mm.pro`, that function no longer referenced `theGraphApiKey`, so `tsup`/tsc failed with `TS6133: 'theGraphApiKey' is declared but its value is never read` → the deploy build errored at `@pancakeswap/chains#build`. (V3/V2 still use the param for the leftover PCS chains, so only `getBlocksSubgraphs` needed it dropped.)

## Impact
The deploy *failed*, so no broken image shipped — prod dex stayed on the previous good image. This unblocks the deploy.

## Test
`pnpm --filter @pancakeswap/chains build` passes locally.
