### PR TITLE
fix(liquidity): show full LP position history (fetch first 1000, not 30)

### DIFF
--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -920,7 +920,7 @@ function PositionHistory_({
       const result = await client.request<PositionHistoryResult>(
         gql`
           query positionHistory($tokenId: String!) {
-            positionSnapshots(where: { position: $tokenId }, orderBy: timestamp, orderDirection: desc, first: 30) {
+            positionSnapshots(where: { position: $tokenId }, orderBy: timestamp, orderDirection: desc, first: 1000) {
               id
               transaction {
                 mints(where: { or: [{ amount0_gt: "0" }, { amount1_gt: "0" }] }) {


### PR DESCRIPTION
LP position-history only fetched the newest **30** snapshots (`first: 30`, desc, no pagination), so positions with >30 lifetime actions lost older history — **initial entry + old collects never appeared**. Data was always in the indexer; the query asked for a tiny newest-first window.

Raises the fetch to `first: 1000` → full history for normal positions.

⚠️ **Depends on** explorer-api MR `fix/position-history-batch` (gitlab `9mm/explorer-api`), which batch-optimizes `positionSnapshots` hydration. Without it `first:1000` takes ~19s (per-snapshot N+1); with it <1s. **Deploy explorer-api first.**

Follow-up: positions with >1000 lifetime actions still need pagination/"load more".